### PR TITLE
feat: allow timestamp override

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,9 @@ func main() {
 		"prefix":      "sensor",
 		"temperature": -4,
 	}).Info("Temperature changes")
+
+	log.WithFields(logrus.Fields{
+		"_timestamp": 1546094013.0234,
+	}).Info("Timestamp override")
 }
 ```

--- a/gelf_log_formatter.go
+++ b/gelf_log_formatter.go
@@ -23,9 +23,15 @@ func (f *GelfFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	data := make(fields, len(entry.Data)+6)
 	blacklist := []string{"_id", "id", "timestamp", "version", "level"}
 
+	var timestamp float64
 	for k, v := range entry.Data {
-
 		if contains(k, blacklist) {
+			continue
+		}
+
+		// Allow overriding timestamp
+		if k == "_timestamp" {
+			timestamp = v.(float64)
 			continue
 		}
 
@@ -40,7 +46,11 @@ func (f *GelfFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 
 	data["version"] = "1.1"
 	data["short_message"] = entry.Message
-	data["timestamp"] = round((float64(entry.Time.UnixNano())/float64(1000000))/float64(1000), 4)
+	if timestamp != 0 {
+		data["timestamp"] = timestamp
+	} else {
+		data["timestamp"] = round((float64(entry.Time.UnixNano())/float64(1000000))/float64(1000), 4)
+	}
 	data["level"] = entry.Level
 	data["level_name"] = entry.Level.String()
 	data["_pid"] = os.Getpid()


### PR DESCRIPTION
There are some cases where a service may wish to override the timestamp - such as when a downstream client is providing the timestamp. This change enables that by using a special `_timestamp` field to denote the new value.

Note that it _must_ be a float64-compatible value, or the type assertion will fail.