### PR TITLE
fix: copy syslog priorities into this package

### DIFF
--- a/gelf_log_formatter.go
+++ b/gelf_log_formatter.go
@@ -6,7 +6,6 @@ package formatter
 import (
 	"encoding/json"
 	"fmt"
-	"log/syslog"
 	"math"
 	"os"
 
@@ -21,14 +20,14 @@ type GelfFormatter struct {
 type fields map[string]interface{}
 
 var (
-	DefaultLevel = syslog.LOG_INFO
-	levelMap     = map[logrus.Level]syslog.Priority{
-		logrus.PanicLevel: syslog.LOG_EMERG,
-		logrus.FatalLevel: syslog.LOG_CRIT,
-		logrus.ErrorLevel: syslog.LOG_ERR,
-		logrus.WarnLevel:  syslog.LOG_WARNING,
-		logrus.InfoLevel:  syslog.LOG_INFO,
-		logrus.DebugLevel: syslog.LOG_DEBUG,
+	DefaultLevel = LOG_INFO
+	levelMap     = map[logrus.Level]Priority{
+		logrus.PanicLevel: LOG_EMERG,
+		logrus.FatalLevel: LOG_CRIT,
+		logrus.ErrorLevel: LOG_ERR,
+		logrus.WarnLevel:  LOG_WARNING,
+		logrus.InfoLevel:  LOG_INFO,
+		logrus.DebugLevel: LOG_DEBUG,
 	}
 )
 
@@ -81,7 +80,7 @@ func round(val float64, places int) float64 {
 	return math.Floor((val*shift)+.5) / shift
 }
 
-func toSyslogLevel(level logrus.Level) syslog.Priority {
+func toSyslogLevel(level logrus.Level) Priority {
 	syslog, ok := levelMap[level]
 	if ok {
 		return syslog

--- a/log_levels.go
+++ b/log_levels.go
@@ -1,0 +1,20 @@
+package formatter
+
+// Copied from log/syslog as that package is not available on windows.
+
+type Priority int
+
+const (
+	// Severity.
+
+	// From /usr/include/sys/syslog.h.
+	// These are the same on Linux, BSD, and OS X.
+	LOG_EMERG Priority = iota
+	LOG_ALERT
+	LOG_CRIT
+	LOG_ERR
+	LOG_WARNING
+	LOG_NOTICE
+	LOG_INFO
+	LOG_DEBUG
+)


### PR DESCRIPTION
On windows the standard package `log/syslog` is not available. Therefore I copied the log level definitions from there to enable usage of this package on windows as well.